### PR TITLE
Rewrite package interface

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,5 +27,6 @@ pipeline {
   }
   options {
     skipDefaultCheckout(true)
+    timeout(time: 10, unit: 'MINUTES')
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,14 @@ pipeline {
   stages {
     stage('Run tests') {
       steps {
+        dir(path: 'SpinWeightedSpheroidalHarmonics') {
+          git 'https://github.com/BlackHolePerturbationToolkit/SpinWeightedSpheroidalHarmonics.git'
+        }
+
+        dir(path: 'KerrGeodesics') {
+          git 'https://github.com/BlackHolePerturbationToolkit/KerrGeodesics.git'
+        }
+
         dir(path: 'ReggeWheeler') {
           checkout scm
           sh 'Tests/AllTests.wls'

--- a/MST.m
+++ b/MST.m
@@ -475,7 +475,7 @@ Derivative[1][MSTRadialUp[s_Integer, l_Integer, m_Integer, q_, \[Epsilon]_, \[Nu
 
 Switch[MST`$MasterFunction,
   "ReggeWheeler",
-  d2R[s_, l_, m_, q_, \[Epsilon]_, \[Lambda]_, r_, R_] := -1/(1-2/r)2/r^2 Derivative[1][R][r]+1/(1-2/r)(l (l+1)/r^2-2(1-s^2)/r^3)R[r]-(\[Epsilon]/2)^2/(1-2/r)^2 R[r];,
+  d2R[s_, l_, m_, q_, \[Epsilon]_, \[Lambda]_, r_, R_] := -1/(1-2/r)2/r^2 Derivative[1][R][r]+1/(1-2/r)(l (l+1)/r^2+2(1-s^2)/r^3)R[r]-(\[Epsilon]/2)^2/(1-2/r)^2 R[r];,
   "Teukolsky",
   d2R[s_, l_, m_, q_, \[Epsilon]_, \[Lambda]_, r_, R_] := (-(-\[Lambda] + 2 I r s \[Epsilon] + (-2 I (-1 + r) s (-q m + (q^2 + r^2) \[Epsilon]/2) + (-q m + (q^2 + r^2) \[Epsilon]/2)^2)/(q^2 - 2 r + r^2)) R[r] - (-2 + 2 r) (1 + s) Derivative[1][R][r])/(q^2 - 2 r + r^2);,
   _, Abort[]

--- a/MST.m
+++ b/MST.m
@@ -504,5 +504,21 @@ Derivative[n_Integer?Positive][MSTRadialUp[s_Integer, l_Integer, m_Integer, q_, 
 ];
 
 
+MSTRadialIn[s_Integer, l_Integer, m_Integer, q_, \[Epsilon]_, \[Nu]_, \[Lambda]_, norm_][r:{_?NumericQ..}] :=
+  Map[MSTRadialIn[s, l, m, q, \[Epsilon], \[Nu], \[Lambda], norm], r];
+
+
+MSTRadialUp[s_Integer, l_Integer, m_Integer, q_, \[Epsilon]_, \[Nu]_, \[Lambda]_, norm_][r:{_?NumericQ..}] :=
+  Map[MSTRadialUp[s, l, m, q, \[Epsilon], \[Nu], \[Lambda], norm], r];
+
+
+Derivative[n_][MSTRadialIn[s_Integer, l_Integer, m_Integer, q_, \[Epsilon]_, \[Nu]_, \[Lambda]_, norm_]][r:{_?NumericQ..}] :=
+  Map[Derivative[n][MSTRadialIn[s, l, m, q, \[Epsilon], \[Nu], \[Lambda], norm]], r];
+
+
+Derivative[n_][MSTRadialUp[s_Integer, l_Integer, m_Integer, q_, \[Epsilon]_, \[Nu]_, \[Lambda]_, norm_]][r:{_?NumericQ..}] :=
+  Map[Derivative[n][MSTRadialUp[s, l, m, q, \[Epsilon], \[Nu], \[Lambda], norm]], r];
+
+
 End[];
 EndPackage[];

--- a/NumericalIntegration.m
+++ b/NumericalIntegration.m
@@ -34,9 +34,21 @@ Psi[s_, l_, \[Omega]_, bc_][{xmin_, xmax_}] :=
   soln
 ];
 
+Psi[s_, l_, \[Omega]_, bc_][All] :=
+ Module[{bcFunc, psiBC, dpsidxBC, xBC, xMin, xMax, soln},
+  If[s==2,
+    bcFunc = Lookup[<|"In" -> ReggeWheelerInBC, "Up" -> ReggeWheelerUpBC|>, bc];
+    {psiBC, dpsidxBC, xBC} = bcFunc[s, l, \[Omega], $MachinePrecision];
+    soln = Function[{x}, Evaluate[Integrator[s, l, \[Omega], psiBC, dpsidxBC, xBC, Min[x, xBC], Max[x, xBC], ReggeWheelerPotential, $MachinePrecision][x]]];
+  ,
+    soln = Function[{x}, $Failed] (*wait for further functionality*)
+  ];
+  soln
+]
+
 
 (*should this be in a module for y1 and y2?*)
-Integrator[s_,l_,\[Omega]_,y1BC_,y2BC_,xBC_,xmin_, xmax_,potential_,precision_]:=Module[{y1,y2,x},
+Integrator[s_,l_,\[Omega]_,y1BC_,y2BC_,xBC_,xmin_?NumericQ,xmax_?NumericQ,potential_,precision_]:=Module[{y1,y2,x},
 	NDSolveValue[
 		{y1'[x]==y2[x],(1-2/x)^2*y2'[x]+2(1-2/x)/x^2*y2[x]+(\[Omega]^2-potential[s,l,x])*y1[x]==0,y1[xBC]==y1BC,y2[xBC]==y2BC},
 		y1,

--- a/NumericalIntegration.m
+++ b/NumericalIntegration.m
@@ -186,7 +186,7 @@ ReggeWheelerInBC[s_Integer,l_Integer,\[Omega]_,workingprecision_]:=
 ]
 
 ReggeWheelerUpBC[s_Integer,l_Integer,\[Omega]_,xmax_,workingprecision_]:=
-	Module[{An=1,Anm1=0,Anm2=0,Anm3=0,Nmax=75,NNmax=1000,n,nn,rstart,rstar,drstardr,increment=0,
+	Module[{An=1,Anm1=0,Anm2=0,Nmax=75,NNmax=1000,n,nn,rstart,rstar,drstardr,increment=0,
 	lastincrement=1*^40,S=0,lastS=0,dS=0,lastdS=0,count=0,r,rn,np,continue=True,precision=workingprecision+10,om,BCinc},
 		(*rstarstart=xmax+2*Log[xmax/2-1]+5*Pi/Abs[om];*)
 		rstart=xmax;
@@ -207,7 +207,6 @@ ReggeWheelerUpBC[s_Integer,l_Integer,\[Omega]_,xmax_,workingprecision_]:=
 				np=n+1;
 				rn=rn*r;
 				lastincrement=Abs[increment];
-				Anm3=Anm2;
 				Anm2=Anm1;
 				Anm1=An;
 				An=N[(I(-1+np-s) (-1+np+s) Anm2)/(np \[Omega])+(I (l+l^2+np-np^2) Anm1)/(2 np \[Omega]),precision];
@@ -220,7 +219,6 @@ ReggeWheelerUpBC[s_Integer,l_Integer,\[Omega]_,xmax_,workingprecision_]:=
 			An=1;
 			Anm1=0;
 			Anm2=0;
-			Anm3=0;
 			increment=0;
 			lastincrement=1*^40;
 			S=0;
@@ -233,8 +231,8 @@ ReggeWheelerUpBC[s_Integer,l_Integer,\[Omega]_,xmax_,workingprecision_]:=
 	If[nn>=NNmax,{Print["The UP boundary condition loop ran out of steps!"],Abort[]}];
 	rstar=rstart+2*Log[rstart/2-1];
 	drstardr = rstart/(rstart-2);
-	<|"Psi"->N[S*Exp[-I*om*rstart],precision],
-	"dPsidx"->N[(-I*om*S*drstardr+dS)*Exp[-I*om*rstart],precision],
+	<|"Psi"->N[S*Exp[-I*om*rstar],precision],
+	"dPsidx"->N[(-I*om*S*drstardr+dS)*Exp[-I*om*rstar],precision],
 	"xBC"->N[rstart,precision]|>
 ]
 

--- a/NumericalIntegration.m
+++ b/NumericalIntegration.m
@@ -17,12 +17,17 @@ Psi[s_, l_, (0|0.), bc_][{xmin_, xmax_}] :=
    Function[y, PsiUpStaticOdd[s,l,y]]
  ];
 
+Psi[s_, l_, \[Omega]_, "In"][xmax_?NumericQ] := Psi[s, l, \[Omega], "In"][{Automatic, xmax}];
+Psi[s_, l_, \[Omega]_, "Up"][xmin_?NumericQ] := Psi[s, l, \[Omega], "Up"][{xmin, Automatic}];
+
 Psi[s_, l_, \[Omega]_, bc_][{xmin_, xmax_}] :=
- Module[{bcFunc, psiBC, dpsidxBC, xBC, soln},
+ Module[{bcFunc, psiBC, dpsidxBC, xBC, xMin, xMax, soln},
   If[s==2,
     bcFunc = Lookup[<|"In" -> ReggeWheelerInBC, "Up" -> ReggeWheelerUpBC|>, bc];
     {psiBC, dpsidxBC, xBC} = bcFunc[s, l, \[Omega], $MachinePrecision];
-    soln = Integrator[s, l, \[Omega], psiBC, dpsidxBC, xBC, xmin, xmax, ReggeWheelerPotential, $MachinePrecision];
+    If[bc === "In" && xmin === Automatic, xMin = xBC, xMin = xmin];
+    If[bc === "Up" && xmax === Automatic, xMax = xBC, xMax = xmax];
+    soln = Integrator[s, l, \[Omega], psiBC, dpsidxBC, xBC, xMin, xMax, ReggeWheelerPotential, $MachinePrecision];
   ,
     soln = Function[{x}, $Failed] (*wait for further functionality*)
   ];

--- a/NumericalIntegration.m
+++ b/NumericalIntegration.m
@@ -9,110 +9,33 @@ BeginPackage["ReggeWheeler`NumericalIntegration`"];
 Begin["`Private`"];
 
 
-SetAttributes[PsiIn, {NumericFunction}];
+SetAttributes[Psi, {NumericFunction}];
 
-PsiIn[s_, l_, \[Omega]_, xmin_, xmax_]:=
-Module[{newassoc},
-	If[\[Omega]==0,
-		newassoc=<|
-				"Psi"->Function[y,PsiInStaticOdd[s,l,y]],
-				"dPsidr"->Function[y,Derivative[0,0,1][PsiInStaticOdd][s,l,y]],
-				"xmin"->xmin,
-				"xmax"->xmax
-				|>;
-		,
-		If[s==2,
-			Module[{boundaryconditions,soln,newAssoc,psiBC,dpsidxBC,xBC},
-				boundaryconditions = ReggeWheelerInBC[s,l,\[Omega],$MachinePrecision];
-				psiBC=boundaryconditions["Psi"];
-				dpsidxBC=boundaryconditions["dPsidx"];
-				xBC=boundaryconditions["xBC"];
-				
-				soln = Integrator[s,l,\[Omega],psiBC,dpsidxBC,xBC,xmax,ReggeWheelerPotential,$MachinePrecision];
-				
-				newassoc=<|
-					"Psi"->soln[[1,1,2]],
-					"dPsidr"->soln[[1,2,2]],
-					"xmin"->xBC,
-					"xmax"->xmax					
-					|>;
-			];,
-			Nothing (*wait for further functionality*)
-		];
-	];
-newassoc
+Psi[s_, l_, (0|0.), bc_][{xmin_, xmax_}] :=
+ If[bc == "In",
+   Function[y, PsiInStaticOdd[s,l,y]],
+   Function[y, PsiUpStaticOdd[s,l,y]]
+ ];
+
+Psi[s_, l_, \[Omega]_, bc_][{xmin_, xmax_}] :=
+ Module[{bcFunc, psiBC, dpsidxBC, xBC, soln},
+  If[s==2,
+    bcFunc = Lookup[<|"In" -> ReggeWheelerInBC, "Up" -> ReggeWheelerUpBC|>, bc];
+    {psiBC, dpsidxBC, xBC} = bcFunc[s, l, \[Omega], $MachinePrecision];
+    soln = Integrator[s, l, \[Omega], psiBC, dpsidxBC, xBC, xmin, xmax, ReggeWheelerPotential, $MachinePrecision];
+  ,
+    soln = Function[{x}, $Failed] (*wait for further functionality*)
+  ];
+  soln
 ];
-
-(*Derivative[1][PsiIn[s_Integer, l_Integer, \[Omega]_, rmin_, rmax_]][x_?InexactNumberQ] :=
- Module[{},
-];
-
-Derivative[n_Integer?Positive][PsiIn[s_Integer, l_Integer, \[Omega]_, rmin_, rmax_]][r0_?InexactNumberQ] :=
- Module[{d2R, pderivs, R, r, i},
-  d2R = -2/(x^2*(1-2/x))*Derivative[1][R][r] -(\[Omega]^2-ReggeWheelerPotential[s,l,x])/(1-2/x)^2*R[r];
-  
-  pderivs = D[R[r_], {r_, i_}] :> D[d2R, {r, i - 2}] /; i >= 2;
-  Do[Derivative[i][R][r] = Simplify[D[Derivative[i - 1][R][r], r] /. pderivs];, {i, 2, n}];
-  Derivative[n][R][r] /. {
-    R'[r] -> PsiIn[s, l, \[Omega]]'[r0],
-    R[r] -> PsiIn[s, l, \[Omega]][r0], r -> r0}
-];*)
-
-
-SetAttributes[PsiUp, {NumericFunction}];
-
-PsiUp[s_, l_, \[Omega]_, xmin_, xmax_]:=
-	Module[{newassoc},
-		If[\[Omega]==0,
-			newassoc=<|
-				"Psi"->Function[y,PsiUpStaticOdd[s,l,y]],
-				"dPsidr"->Function[y,Derivative[0,0,1][PsiUpStaticOdd][s,l,y]],
-				"xmin"->xmin,
-				"xmax"->xmax
-				|>;
-			,
-			If[s==2,
-				Module[{boundaryconditions,soln,newAssoc,psiBC,dpsidxBC,xBC},
-					boundaryconditions = ReggeWheelerUpBC[s,l,\[Omega],xmax,$MachinePrecision];
-					psiBC=boundaryconditions["Psi"];
-					dpsidxBC=boundaryconditions["dPsidx"];
-					xBC=boundaryconditions["xBC"];
-					soln = Integrator[s,l,\[Omega],psiBC,dpsidxBC,xBC,xmin,ReggeWheelerPotential,$MachinePrecision];
-					newassoc= <|
-						"Psi"->soln[[1,1,2]],
-						"dPsidr"->soln[[1,2,2]],
-						"xmin"->xmin,
-						"xmax"->xBC
-					|>
-				],
-			newassoc=Nothing (*wait for further functionality*)
-			];
-		];
-		newassoc
-	];
-
-(*Derivative[1][PsiUp[s_Integer, l_Integer, \[Omega]_, rmin_, rmax_]][x_?InexactNumberQ] :=
- Module[{},
-];
-
-Derivative[n_Integer?Positive][PsiUp[s_Integer, l_Integer, \[Omega]_, rmin_, rmax_]][r0_?InexactNumberQ] :=
- Module[{d2R, pderivs, R, r, i},
-  d2R = -2/(x^2*(1-2/x))*Derivative[1][R][r] -(\[Omega]^2-ReggeWheelerPotential[s,l,x])/(1-2/x)^2*R[r];
-
-  pderivs = D[R[r_], {r_, i_}] :> D[d2R, {r, i - 2}] /; i >= 2;
-  Do[Derivative[i][R][r] = Simplify[D[Derivative[i - 1][R][r], r] /. pderivs];, {i, 2, n}];
-  Derivative[n][R][r] /. {
-    R'[r] -> PsiUp[s, l, \[Omega]]'[r0],
-    R[r] -> PsiUp[s, l, \[Omega]][r0], r -> r0}
-];*)
 
 
 (*should this be in a module for y1 and y2?*)
-Integrator[s_,l_,\[Omega]_,y1BC_,y2BC_,xBC_,xend_,potential_,precision_]:=Module[{y1,y2,x},
-	NDSolve[
+Integrator[s_,l_,\[Omega]_,y1BC_,y2BC_,xBC_,xmin_, xmax_,potential_,precision_]:=Module[{y1,y2,x},
+	NDSolveValue[
 		{y1'[x]==y2[x],(1-2/x)^2*y2'[x]+2(1-2/x)/x^2*y2[x]+(\[Omega]^2-potential[s,l,x])*y1[x]==0,y1[xBC]==y1BC,y2[xBC]==y2BC},
-		{y1,y2},
-		If[xBC<xend,{x,xBC,xend},{x,xend,xBC}],
+		y1,
+		{x, xmin, xmax},
 		Method->"StiffnessSwitching",
 		MaxSteps->Infinity,
 		WorkingPrecision->precision,
@@ -182,14 +105,14 @@ ReggeWheelerInBC[s_Integer,l_Integer,\[Omega]_,workingprecision_]:=
 	drstardr = Reh/rm2M;
 	psi=Exp[I*om*rstar]*expeh;
 	dpsidr=Exp[I*om*rstar]*Dexpeh+I*om*drstardr*psi;
-	<|"Psi"->N[psi,precision],"dPsidx"->N[dpsidr,precision],"xBC"->N[Reh,precision]|>
+	{N[psi,precision], N[dpsidr,precision], N[Reh,precision]}
 ]
 
-ReggeWheelerUpBC[s_Integer,l_Integer,\[Omega]_,xmax_,workingprecision_]:=
+ReggeWheelerUpBC[s_Integer,l_Integer,\[Omega]_,workingprecision_]:=
 	Module[{An=1,Anm1=0,Anm2=0,Nmax=75,NNmax=1000,n,nn,rstart,rstar,drstardr,increment=0,
 	lastincrement=1*^40,S=0,lastS=0,dS=0,lastdS=0,count=0,r,rn,np,continue=True,precision=workingprecision+10,om,BCinc},
 		(*rstarstart=xmax+2*Log[xmax/2-1]+5*Pi/Abs[om];*)
-		rstart=xmax;
+		rstart=10000;
 		om=-\[Omega];
 		nn=1;
 		r=rstart;
@@ -231,9 +154,9 @@ ReggeWheelerUpBC[s_Integer,l_Integer,\[Omega]_,xmax_,workingprecision_]:=
 	If[nn>=NNmax,{Print["The UP boundary condition loop ran out of steps!"],Abort[]}];
 	rstar=rstart+2*Log[rstart/2-1];
 	drstardr = rstart/(rstart-2);
-	<|"Psi"->N[S*Exp[-I*om*rstar],precision],
-	"dPsidx"->N[(-I*om*S*drstardr+dS)*Exp[-I*om*rstar],precision],
-	"xBC"->N[rstart,precision]|>
+	{N[S*Exp[-I*om*rstar],precision],
+	 N[(-I*om*S*drstardr+dS)*Exp[-I*om*rstar],precision],
+	 N[rstart,precision]}
 ]
 
 

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -1,5 +1,13 @@
 (* ::Package:: *)
 
+(* ::Title:: *)
+(*ReggeWheeler package*)
+
+
+(* ::Section::Closed:: *)
+(*Create Package*)
+
+
 BeginPackage["ReggeWheeler`ReggeWheelerRadial`",
   {
     "ReggeWheeler`NumericalIntegration`",
@@ -8,12 +16,24 @@ BeginPackage["ReggeWheeler`ReggeWheelerRadial`",
     "SpinWeightedSpheroidalHarmonics`"
   }];
 
+
+(* Usage messages *)
 ReggeWheelerRadial::usage = "ReggeWheelerRadial[s, l, \[Omega]] computes homogeneous solutions to the Regge Wheeler equation."
 ReggeWheelerRadialFunction::usage = "ReggeWheelerRadialFunction[s, l, \[Omega], assoc] is an object representing a homogeneous solution to the Regge Wheeler equation."
 
+
 Begin["`Private`"];
 
-Options[ReggeWheelerRadial] = {Method -> {"NumericalIntegration", "rmin" -> 4, "rmax" -> 20}, "BoundaryConditions" -> {"In","Up"}};
+
+(* ::Section::Closed:: *)
+(*ReggeWheelerRadial*)
+
+
+Options[ReggeWheelerRadial] = {
+  Method -> {"NumericalIntegration", "rmin" -> 4, "rmax" -> 20},
+  "BoundaryConditions" -> {"In","Up"}
+};
+
 
 ReggeWheelerRadial[s_Integer, l_Integer, \[Omega]_, OptionsPattern[]] :=
  Module[{assocIn, assocUp, \[Lambda], \[Nu], solFuncs, method, norms, m = 0, a=0},
@@ -63,6 +83,11 @@ ReggeWheelerRadial[s_Integer, l_Integer, \[Omega]_, OptionsPattern[]] :=
     "Up" -> ReggeWheelerRadialFunction[s, l, \[Omega], assocUp]|>
 ];
 
+
+(* ::Section::Closed:: *)
+(*ReggeWheelerRadialFunction*)
+
+
 Format[ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_]] := 
   "ReggeWheelerRadialFunction["<>ToString[s]<>","<>ToString[l]<>","<>ToString[\[Omega]]<>",<<>>]";
 
@@ -74,6 +99,10 @@ ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_][r_?NumericQ] :=
 
 Derivative[n_][ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_]][r_?NumericQ] :=
   assoc["RadialFunction"]'[r];
+
+
+(* ::Section::Closed:: *)
+(*End Package*)
 
 
 End[]

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -55,8 +55,8 @@ ReggeWheelerRadialNumericalIntegration[s_Integer, l_Integer, \[Omega]_, opts:Opt
       "BoundaryConditions" -> bc, "Amplitudes" -> ns,
       "RadialFunction" -> sf[domain]
      ]
-  ];
-  
+    ];
+
   (* Determine which boundary conditions the homogeneous solution(s) should satisfy *)
   BCs = OptionValue[{ReggeWheelerRadial, ReggeWheelerRadialNumericalIntegration}, {opts}, "BoundaryConditions"];
   If[!MatchQ[BCs, "In"|"Up"|{("In"|"Up")..}], 
@@ -207,7 +207,7 @@ ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_][r_?NumericQ] :=
   assoc["RadialFunction"][r];
 
 Derivative[n_][ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_]][r_?NumericQ] :=
-  assoc["RadialFunction"]'[r];
+  Derivative[n][assoc["RadialFunction"]][r];
 
 
 (* ::Section::Closed:: *)

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -82,7 +82,7 @@ ReggeWheelerRadialNumericalIntegration[s_Integer, l_Integer, \[Omega]_, opts:Opt
   RWRF[bc_, ns_, sf_] :=
     ReggeWheelerRadialFunction[s, l, \[Omega],
      Association["s" -> s, "l" -> l, "\[Omega]" -> \[Omega], "Eigenvalue" -> \[Lambda],
-      "Method" -> {"MST", "RenormalizedAngularMomentum" -> \[Nu]},
+      "Method" -> {"NumericalIntegration", "rmin" -> rmin, "rmax" -> rmax},
       "BoundaryConditions" -> bc, "Amplitudes" -> ns,
       "RadialFunction" -> sf
      ]

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -13,7 +13,8 @@ BeginPackage["ReggeWheeler`ReggeWheelerRadial`",
     "ReggeWheeler`NumericalIntegration`",
     "ReggeWheeler`MST`RenormalizedAngularMomentum`",
     "ReggeWheeler`MST`MST`",
-    "SpinWeightedSpheroidalHarmonics`"
+    "SpinWeightedSpheroidalHarmonics`",
+    "DifferentialEquations`InterpolatingFunctionAnatomy`"
   }];
 
 
@@ -52,13 +53,17 @@ ReggeWheelerRadialNumericalIntegration[s_Integer, l_Integer, \[Omega]_, opts:Opt
 
   (* Function to construct a single ReggeWheelerRadialFunction *)
   RWRF[bc_, ns_, sf_, domain_] :=
+   Module[{solutionFunction},
+    solutionFunction = sf[domain];
     ReggeWheelerRadialFunction[s, l, \[Omega],
      Association["s" -> s, "l" -> l, "\[Omega]" -> \[Omega], "Eigenvalue" -> \[Lambda],
-      "Method" -> {"NumericalIntegration", "Domain" -> domain},
+      "Method" -> {"NumericalIntegration"},
       "BoundaryConditions" -> bc, "Amplitudes" -> ns,
-      "RadialFunction" -> sf[domain]
+      "Domain" -> If[domain === All, {2, \[Infinity]}, First[InterpolatingFunctionDomain[solutionFunction]]],
+      "RadialFunction" -> solutionFunction
      ]
-    ];
+    ]
+   ];
 
   (* Determine which boundary conditions the homogeneous solution(s) should satisfy *)
   BCs = OptionValue[{ReggeWheelerRadial, ReggeWheelerRadialNumericalIntegration}, {opts}, "BoundaryConditions"];
@@ -120,7 +125,7 @@ ReggeWheelerRadialMST[s_Integer, l_Integer, \[Omega]_, opts:OptionsPattern[]] :=
      Association["s" -> s, "l" -> l, "\[Omega]" -> \[Omega], "Eigenvalue" -> \[Lambda],
       "Method" -> {"MST", "RenormalizedAngularMomentum" -> \[Nu]},
       "BoundaryConditions" -> bc, "Amplitudes" -> ns,
-      "RadialFunction" -> sf
+      "Domain" -> {2, \[Infinity]}, "RadialFunction" -> sf
      ]
     ];
 

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -34,8 +34,8 @@ SyntaxInformation[ReggeWheelerRadial] =
 
 
 Options[ReggeWheelerRadial] = {
-  Method -> {"NumericalIntegration", "rmin" -> 4, "rmax" -> 20},
-  "BoundaryConditions" -> {"In","Up"}
+  Method -> {"MST", "RenormalizedAngularMomentum" -> "Monodromy"},
+  "BoundaryConditions" -> {"In", "Up"}
 };
 
 

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -25,7 +25,7 @@ ReggeWheelerRadialFunction::usage = "ReggeWheelerRadialFunction[s, l, \[Omega], 
 
 (* Error messages *)
 ReggeWheelerRadial::optx = "Unknown options in `1`";
-ReggeWheelerRadialFunction::dmval = "Radius `1` lies outside the range of allowed values. Results may be incorrect.";
+ReggeWheelerRadialFunction::dmval = "Radius `1` lies outside the computational domain. Results may be incorrect.";
 
 
 Begin["`Private`"];

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -25,6 +25,7 @@ ReggeWheelerRadialFunction::usage = "ReggeWheelerRadialFunction[s, l, \[Omega], 
 
 (* Error messages *)
 ReggeWheelerRadial::optx = "Unknown options in `1`";
+ReggeWheelerRadialFunction::dmval = "Radius `1` lies outside the range of allowed values. Results may be incorrect.";
 
 
 Begin["`Private`"];
@@ -212,10 +213,23 @@ ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_][y_String] /; !MemberQ[{"Ra
   assoc[y];
 
 ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_][r_?NumericQ] :=
-  assoc["RadialFunction"][r];
+ Module[{rmin, rmax},
+  {rmin, rmax} = assoc["Domain"];
+  If[!(rmin <= r <= rmax),
+    Message[ReggeWheelerRadialFunction::dmval, r];
+  ];
+  Quiet[assoc["RadialFunction"][r], InterpolatingFunction::dmval]
+ ];
+  
 
 Derivative[n_][ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_]][r_?NumericQ] :=
-  Derivative[n][assoc["RadialFunction"]][r];
+ Module[{rmin, rmax},
+  {rmin, rmax} = assoc["Domain"];
+  If[!(rmin <= r <= rmax),
+    Message[ReggeWheelerRadialFunction::dmval, r];
+  ];
+  Quiet[Derivative[n][assoc["RadialFunction"]][r], InterpolatingFunction::dmval]
+ ];
 
 
 (* ::Section::Closed:: *)

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -214,11 +214,15 @@ Format[ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_]] :=
 ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_][y_String] /; !MemberQ[{"RadialFunction"}, y] :=
   assoc[y];
 
+
+outsideDomainQ[r_, rmin_, rmax_] := Min[r]<rmin || Max[r]>rmax;
+
+
 ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_][r:(_?NumericQ|{_?NumericQ..})] :=
  Module[{rmin, rmax},
   {rmin, rmax} = assoc["Domain"];
-  If[!(rmin <= r <= rmax),
-    Message[ReggeWheelerRadialFunction::dmval, r];
+  If[outsideDomainQ[r, rmin, rmax],
+    Message[ReggeWheelerRadialFunction::dmval, #]& /@ Select[Flatten[{r}], outsideDomainQ[#, rmin, rmax]&];
   ];
   Quiet[assoc["RadialFunction"][r], InterpolatingFunction::dmval]
  ];
@@ -227,8 +231,8 @@ ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_][r:(_?NumericQ|{_?NumericQ.
 Derivative[n_][ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_]][r:(_?NumericQ|{_?NumericQ..})] :=
  Module[{rmin, rmax},
   {rmin, rmax} = assoc["Domain"];
-  If[!(rmin <= r <= rmax),
-    Message[ReggeWheelerRadialFunction::dmval, r];
+  If[outsideDomainQ[r, rmin, rmax],
+    Message[ReggeWheelerRadialFunction::dmval, #]& /@ Select[Flatten[{r}], outsideDomainQ[#, rmin, rmax]&];
   ];
   Quiet[Derivative[n][assoc["RadialFunction"]][r], InterpolatingFunction::dmval]
  ];

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -73,7 +73,7 @@ ReggeWheelerRadialNumericalIntegration[s_Integer, l_Integer, \[Omega]_, opts:Opt
     ];
     domains = Lookup[domains, BCs, None];
   ,
-    If[Not[MatchQ[domains, {_?NumericQ, _?NumericQ}]],
+    If[Not[MatchQ[domains, {_?NumericQ, _?NumericQ} | (_?NumericQ)]],
       Message[ReggeWheelerRadial::optx, "Domain" -> domains];
       Return[$Failed];
     ];

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -4,7 +4,8 @@ BeginPackage["ReggeWheeler`ReggeWheelerRadial`",
   {
     "ReggeWheeler`NumericalIntegration`",
     "ReggeWheeler`MST`RenormalizedAngularMomentum`",
-    "ReggeWheeler`MST`MST`"
+    "ReggeWheeler`MST`MST`",
+    "SpinWeightedSpheroidalHarmonics`"
   }];
 
 ReggeWheelerRadial::usage = "ReggeWheelerRadial[s, l, \[Omega]] computes solutions to the Regge Wheeler equation."

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -42,6 +42,9 @@ Options[ReggeWheelerRadialNumericalIntegration] = {
   "BoundaryConditions" -> None};
 
 
+domainQ[domain_] := MatchQ[domain, {_?NumericQ, _?NumericQ} | (_?NumericQ)];
+
+
 ReggeWheelerRadialNumericalIntegration[s_Integer, l_Integer, \[Omega]_, opts:OptionsPattern[]] :=
  Module[{\[Lambda], RWRF, BCs, norms, solFuncs, domains, m = 0, a=0},
   (* Compute the eigenvalue *)
@@ -67,13 +70,13 @@ ReggeWheelerRadialNumericalIntegration[s_Integer, l_Integer, \[Omega]_, opts:Opt
   (* Domain over which the numerical solution can be evaluated *)
   domains = OptionValue["Domain"];
   If[ListQ[BCs],
-    If[Not[MatchQ[domains, (List|Association)[Rule[_,_]..]]],
+    If[!MatchQ[domains, (List|Association)[Rule[_,_?domainQ]..]],
       Message[ReggeWheelerRadial::optx, "Domain" -> domains];
       Return[$Failed];
     ];
     domains = Lookup[domains, BCs, None];
   ,
-    If[Not[MatchQ[domains, {_?NumericQ, _?NumericQ} | (_?NumericQ)]],
+    If[!domainQ[domains],
       Message[ReggeWheelerRadial::optx, "Domain" -> domains];
       Return[$Failed];
     ];

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -117,16 +117,17 @@ ReggeWheelerRadialMST[s_Integer, l_Integer, \[Omega]_, opts:OptionsPattern[]] :=
     Return[$Failed];
   ];
 
-  (* Compute the asymptotic normalisations and rescale to get unit transmission coefficient *)
+  (* Compute the asymptotic normalisations *)
   norms = ReggeWheeler`MST`MST`Private`Amplitudes[s, l, m, a, 2\[Omega], \[Nu], \[Lambda]];
-  norms = norms/norms[[All, "Transmission"]];
 
   (* Solution functions for the specified boundary conditions *)
   solFuncs =
     BCs /. {"In" -> ReggeWheeler`MST`MST`Private`MSTRadialIn[s,l,m,a,2\[Omega],\[Nu],\[Lambda],norms["In"]["Transmission"]],
             "Up" -> ReggeWheeler`MST`MST`Private`MSTRadialUp[s,l,m,a,2\[Omega],\[Nu],\[Lambda],norms["Up"]["Transmission"]]};
 
-  (* We only need the normalisations for the specified boundary conditions *)
+  (* Select normalisation coefficients for the specified boundary conditions and rescale
+     to give unit transmission coefficient. *)
+  norms = norms/norms[[All, "Transmission"]];
   norms = BCs /. norms;
 
   (* Function to construct a ReggeWheelerRadialFunction *)

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -206,6 +206,8 @@ ReggeWheelerRadial[s_Integer, l_Integer, \[Omega]_?InexactNumberQ, opts:OptionsP
 (*ReggeWheelerRadialFunction*)
 
 
+SetAttributes[ReggeWheelerRadialFunction, {NumericFunction}];
+
 Format[ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_]] := 
   "ReggeWheelerRadialFunction["<>ToString[s]<>","<>ToString[l]<>","<>ToString[\[Omega]]<>",<<>>]";
 

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -4,8 +4,7 @@ BeginPackage["ReggeWheeler`ReggeWheelerRadial`",
   {
     "ReggeWheeler`NumericalIntegration`",
     "ReggeWheeler`MST`RenormalizedAngularMomentum`",
-    "ReggeWheeler`MST`MST`",
-    "SpinWeightedSpheroidalHarmonics`"
+    "ReggeWheeler`MST`MST`"
   }];
 
 ReggeWheelerRadial::usage = "ReggeWheelerRadial[s, l, \[Omega]] computes solutions to the Regge Wheeler equation."
@@ -21,20 +20,18 @@ ReggeWheelerRadial[s_Integer, l_Integer, \[Omega]_, OptionsPattern[]] :=
 
   Switch[OptionValue[Method],
     "MST"|{"MST", ___},
-
-      \[Nu] = RenormalizedAngularMomentum[s, l, m, a, \[Omega], \[Lambda](*, Method->"RenormalizedAngularMomentum"/.OptionValue[Method][[2;;]]*) ];
+      \[Nu] = RenormalizedAngularMomentum[s, l, m, a, \[Omega], \[Lambda], Method->"RenormalizedAngularMomentum"/.OptionValue[Method][[2;;]] ];
       method = {"MST", "RenormalizedAngularMomentum" -> \[Nu]};
       norms = ReggeWheeler`MST`MST`Private`Amplitudes[s,l,m,a,2\[Omega],\[Nu],\[Lambda]];
-
       solFuncs = OptionValue["BoundaryConditions"] /.
         {"In" -> ReggeWheeler`MST`MST`Private`MSTRadialIn[s,l,m,a,2\[Omega],\[Nu],\[Lambda],norms["In"]["Transmission"]],
          "Up" -> ReggeWheeler`MST`MST`Private`MSTRadialUp[s,l,m,a,2\[Omega],\[Nu],\[Lambda],norms["Up"]["Transmission"]]};
       norms = norms/norms[[All, "Transmission"]];,
     {"NumericalIntegration", "rmin" -> _, "rmax" -> _},
-      method = {"NumericalIntegtration", Association[OptionValue[Method][[2;;]]]};
+      method = Association[OptionValue[Method][[2;;]]];
       solFuncs = 
-        {ReggeWheeler`NumericalIntegration`Private`PsiIn[s, l, \[Omega], method[[2]]["rmin"], method[[2]]["rmax"]],
-         ReggeWheeler`NumericalIntegration`Private`PsiUp[s, l, \[Omega], method[[2]]["rmin"], method[[2]]["rmax"]]};
+        {ReggeWheeler`NumericalIntegration`Private`PsiIn[s, l, \[Omega], method["rmin"], method["rmax"]],
+         ReggeWheeler`NumericalIntegration`Private`PsiUp[s, l, \[Omega], method["rmin"], method["rmax"]]};
   ];
 
   assoc = Association[

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -29,6 +29,10 @@ Begin["`Private`"];
 (*ReggeWheelerRadial*)
 
 
+SyntaxInformation[ReggeWheelerRadial] =
+ {"ArgumentsPattern" -> {_, _, _, OptionsPattern[]}};
+
+
 Options[ReggeWheelerRadial] = {
   Method -> {"NumericalIntegration", "rmin" -> 4, "rmax" -> 20},
   "BoundaryConditions" -> {"In","Up"}

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -8,8 +8,8 @@ BeginPackage["ReggeWheeler`ReggeWheelerRadial`",
     "SpinWeightedSpheroidalHarmonics`"
   }];
 
-ReggeWheelerRadial::usage = "ReggeWheelerRadial[s, l, \[Omega]] computes solutions to the Regge Wheeler equation."
-ReggeWheelerRadialFunction::usage = "ReggeWheelerRadialFunction[s, l, \[Omega], assoc] an object representing solutions to the Regge Wheeler equation."
+ReggeWheelerRadial::usage = "ReggeWheelerRadial[s, l, \[Omega]] computes homogeneous solutions to the Regge Wheeler equation."
+ReggeWheelerRadialFunction::usage = "ReggeWheelerRadialFunction[s, l, \[Omega], assoc] is an object representing a homogeneous solution to the Regge Wheeler equation."
 
 Begin["`Private`"];
 

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -42,7 +42,7 @@ Options[ReggeWheelerRadialNumericalIntegration] = {
   "BoundaryConditions" -> None};
 
 
-domainQ[domain_] := MatchQ[domain, {_?NumericQ, _?NumericQ} | (_?NumericQ)];
+domainQ[domain_] := MatchQ[domain, {_?NumericQ, _?NumericQ} | (_?NumericQ) | All];
 
 
 ReggeWheelerRadialNumericalIntegration[s_Integer, l_Integer, \[Omega]_, opts:OptionsPattern[]] :=

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -214,7 +214,7 @@ Format[ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_]] :=
 ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_][y_String] /; !MemberQ[{"RadialFunction"}, y] :=
   assoc[y];
 
-ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_][r_?NumericQ] :=
+ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_][r:(_?NumericQ|{_?NumericQ..})] :=
  Module[{rmin, rmax},
   {rmin, rmax} = assoc["Domain"];
   If[!(rmin <= r <= rmax),
@@ -222,9 +222,9 @@ ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_][r_?NumericQ] :=
   ];
   Quiet[assoc["RadialFunction"][r], InterpolatingFunction::dmval]
  ];
-  
 
-Derivative[n_][ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_]][r_?NumericQ] :=
+
+Derivative[n_][ReggeWheelerRadialFunction[s_, l_, \[Omega]_, assoc_]][r:(_?NumericQ|{_?NumericQ..})] :=
  Module[{rmin, rmax},
   {rmin, rmax} = assoc["Domain"];
   If[!(rmin <= r <= rmax),

--- a/ReggeWheelerRadial.m
+++ b/ReggeWheelerRadial.m
@@ -22,10 +22,131 @@ ReggeWheelerRadial::usage = "ReggeWheelerRadial[s, l, \[Omega]] computes homogen
 ReggeWheelerRadialFunction::usage = "ReggeWheelerRadialFunction[s, l, \[Omega], assoc] is an object representing a homogeneous solution to the Regge Wheeler equation."
 
 
+(* Error messages *)
+ReggeWheelerRadial::optx = "Unknown options in `1`";
+
+
 Begin["`Private`"];
 
 
 (* ::Section::Closed:: *)
+(*ReggeWheelerRadial*)
+
+
+(* ::Subsection::Closed:: *)
+(*Numerical Integration Method*)
+
+
+Options[ReggeWheelerRadialNumericalIntegration] = {
+  "rmin" -> None,
+  "rmax" -> None,
+  "BoundaryConditions" -> None};
+
+
+ReggeWheelerRadialNumericalIntegration[s_Integer, l_Integer, \[Omega]_, opts:OptionsPattern[]] :=
+ Module[{\[Lambda], rmin, rmax, BCs, norms, solFuncs, RWRF, m = 0, a=0},
+  (* Compute the eigenvalue *)
+  \[Lambda] = SpinWeightedSpheroidalEigenvalue[s, l, m, a \[Omega]];
+
+  (* rmin and rmax *)
+  rmin = OptionValue["rmin"];
+  rmax = OptionValue["rmax"];
+  If[Not[NumericQ[rmin]],
+    Message[ReggeWheelerRadial::optx, "rmin" -> rmin];
+    Return[$Failed];
+  ];
+  If[Not[NumericQ[rmax]],
+    Message[ReggeWheelerRadial::optx, "rmax" -> rmax];
+    Return[$Failed];
+  ];
+  
+  (* Determine which boundary conditions the homogeneous solution(s) should satisfy *)
+  BCs = OptionValue[{ReggeWheelerRadial, ReggeWheelerRadialNumericalIntegration}, {opts}, "BoundaryConditions"];
+  If[!MatchQ[BCs, "In"|"Up"|{("In"|"Up")..}], 
+    Message[ReggeWheelerRadial::optx, "BoundaryConditions" -> BCs];
+    Return[$Failed];
+  ];
+
+  (* Asymptotic normalizations such that we have unit transmission coefficient *)
+  norms = <|"In" -> <|"Transmission" -> 1|>, "Up" -> <|"Transmission" -> 1|>|>;
+
+  (* Solution functions for the specified boundary conditions *)
+  solFuncs =
+    BCs /. {"In" -> ReggeWheeler`NumericalIntegration`Private`PsiIn[s, l, \[Omega], rmin, rmax]["Psi"],
+            "Up" -> ReggeWheeler`NumericalIntegration`Private`PsiUp[s, l, \[Omega], rmin, rmax]["Psi"]};
+
+  (* We only need the normalisations for the specified boundary conditions *)
+  norms = BCs /. norms;
+
+  (* Function to construct a ReggeWheelerRadialFunction *)
+  RWRF[bc_, ns_, sf_] :=
+    ReggeWheelerRadialFunction[s, l, \[Omega],
+     Association["s" -> s, "l" -> l, "\[Omega]" -> \[Omega], "Eigenvalue" -> \[Lambda],
+      "Method" -> {"MST", "RenormalizedAngularMomentum" -> \[Nu]},
+      "BoundaryConditions" -> bc, "Amplitudes" -> ns,
+      "RadialFunction" -> sf
+     ]
+    ];
+
+  If[ListQ[BCs],
+    Return[Association[MapThread[#1 -> RWRF[#1, #2, #3]&, {BCs, norms, solFuncs}]]],
+    Return[RWRF[BCs, norms, solFuncs]]
+  ];
+];
+
+
+(* ::Subsection::Closed:: *)
+(*MST Method*)
+
+
+Options[ReggeWheelerRadialMST] = {
+  "RenormalizedAngularMomentum" -> "Monodromy",
+  "BoundaryConditions" -> None};
+
+
+ReggeWheelerRadialMST[s_Integer, l_Integer, \[Omega]_, opts:OptionsPattern[]] :=
+ Module[{\[Lambda], \[Nu], BCs, norms, solFuncs, RWRF, m = 0, a=0},
+  (* Compute the eigenvalue and renormalized angular momentum *)
+  \[Lambda] = SpinWeightedSpheroidalEigenvalue[s, l, m, a \[Omega]];
+  \[Nu] = RenormalizedAngularMomentum[s, l, m, a, \[Omega], \[Lambda], Method -> OptionValue["RenormalizedAngularMomentum"]];
+
+  (* Determine which boundary conditions the homogeneous solution(s) should satisfy *)
+  BCs = OptionValue[{ReggeWheelerRadial, ReggeWheelerRadialMST}, {opts}, "BoundaryConditions"];
+  If[!MatchQ[BCs, "In"|"Up"|{("In"|"Up")..}], 
+    Message[ReggeWheelerRadial::optx, "BoundaryConditions" -> BCs];
+    Return[$Failed];
+  ];
+
+  (* Compute the asymptotic normalisations and rescale to get unit transmission coefficient *)
+  norms = ReggeWheeler`MST`MST`Private`Amplitudes[s, l, m, a, 2\[Omega], \[Nu], \[Lambda]];
+  norms = norms/norms[[All, "Transmission"]];
+
+  (* Solution functions for the specified boundary conditions *)
+  solFuncs =
+    BCs /. {"In" -> ReggeWheeler`MST`MST`Private`MSTRadialIn[s,l,m,a,2\[Omega],\[Nu],\[Lambda],norms["In"]["Transmission"]],
+            "Up" -> ReggeWheeler`MST`MST`Private`MSTRadialUp[s,l,m,a,2\[Omega],\[Nu],\[Lambda],norms["Up"]["Transmission"]]};
+
+  (* We only need the normalisations for the specified boundary conditions *)
+  norms = BCs /. norms;
+
+  (* Function to construct a ReggeWheelerRadialFunction *)
+  RWRF[bc_, ns_, sf_] :=
+    ReggeWheelerRadialFunction[s, l, \[Omega],
+     Association["s" -> s, "l" -> l, "\[Omega]" -> \[Omega], "Eigenvalue" -> \[Lambda],
+      "Method" -> {"MST", "RenormalizedAngularMomentum" -> \[Nu]},
+      "BoundaryConditions" -> bc, "Amplitudes" -> ns,
+      "RadialFunction" -> sf
+     ]
+    ];
+
+  If[ListQ[BCs],
+    Return[Association[MapThread[#1 -> RWRF[#1, #2, #3]&, {BCs, norms, solFuncs}]]],
+    Return[RWRF[BCs, norms, solFuncs]]
+  ];
+];
+
+
+(* ::Subsection::Closed:: *)
 (*ReggeWheelerRadial*)
 
 
@@ -34,57 +155,38 @@ SyntaxInformation[ReggeWheelerRadial] =
 
 
 Options[ReggeWheelerRadial] = {
-  Method -> {"MST", "RenormalizedAngularMomentum" -> "Monodromy"},
+  Method -> "MST",
   "BoundaryConditions" -> {"In", "Up"}
 };
 
 
-ReggeWheelerRadial[s_Integer, l_Integer, \[Omega]_, OptionsPattern[]] :=
- Module[{assocIn, assocUp, \[Lambda], \[Nu], solFuncs, method, norms, m = 0, a=0},
-  \[Lambda] = SpinWeightedSpheroidalEigenvalue[s, l, m, a \[Omega]];
-
-  Switch[OptionValue[Method],
-    "MST"|{"MST", ___},
-      \[Nu] = RenormalizedAngularMomentum[s, l, m, a, \[Omega], \[Lambda], Method->"RenormalizedAngularMomentum"/.OptionValue[Method][[2;;]] ];
-      method = {"MST", "RenormalizedAngularMomentum" -> \[Nu]};
-      norms = ReggeWheeler`MST`MST`Private`Amplitudes[s,l,m,a,2\[Omega],\[Nu],\[Lambda]];
-      solFuncs =
-       <|"In" -> ReggeWheeler`MST`MST`Private`MSTRadialIn[s,l,m,a,2\[Omega],\[Nu],\[Lambda],norms["In"]["Transmission"]],
-         "Up" -> ReggeWheeler`MST`MST`Private`MSTRadialUp[s,l,m,a,2\[Omega],\[Nu],\[Lambda],norms["Up"]["Transmission"]]|>;
-      norms = norms/norms[[All, "Transmission"]];,
-    {"NumericalIntegration", "rmin" -> _, "rmax" -> _},
-      method = Association[OptionValue[Method][[2;;]]];
-      solFuncs = 
-       <|"In" -> ReggeWheeler`NumericalIntegration`Private`PsiIn[s, l, \[Omega], method["rmin"], method["rmax"]]["Psi"],
-         "Up" -> ReggeWheeler`NumericalIntegration`Private`PsiUp[s, l, \[Omega], method["rmin"], method["rmax"]]["Psi"]|>;
+ReggeWheelerRadial[s_Integer, l_Integer, \[Omega]_?InexactNumberQ, opts:OptionsPattern[]] :=
+ Module[{RWRF, subopts},
+  (* All options  except for Method are passed on. Method is a special case where
+     only suboptions are passed on, if there are any. *)
+  subopts = Cases[{opts}, Except[Method -> _]];
+  If[ListQ[OptionValue[Method]],
+    subopts = Join[Rest[OptionValue[Method]], subopts];
   ];
 
-  assocIn = Association[
-    "s" -> s,
-    "l" -> l,
-    "m" -> m,
-    "\[Omega]" -> \[Omega],
-    "Method" -> method,
-    "BoundaryConditions" -> OptionValue["BoundaryConditions"],
-    "Eigenvalue" -> \[Lambda],
-    "Amplitudes" -> norms["In"],
-    "RadialFunction" -> solFuncs["In"]
-    ];
+  (* Decide which implementation to use *)
+  Switch[OptionValue[Method],
+    "MST" | {"MST", Rule[_,_]...},
+      RWRF = ReggeWheelerRadialMST,
+    "NumericalIntegration" | {"NumericalIntegration", ___},
+      RWRF = ReggeWheelerRadialNumericalIntegration;,
+    _,
+      Message[ReggeWheelerRadial::optx, Method -> OptionValue[Method]];
+      Return[$Failed];
+  ];
 
-  assocUp = Association[
-    "s" -> s,
-    "l" -> l,
-    "m" -> m,
-    "\[Omega]" -> \[Omega],
-    "Method" -> method,
-    "BoundaryConditions" -> "Up",
-    "Eigenvalue" -> \[Lambda],
-    "Amplitudes" -> norms["Up"],
-    "RadialFunction" -> solFuncs["Up"]
-    ];
+  (* Check only supported sub-options have been specified *)  
+  If[subopts =!= (subopts = FilterRules[subopts, Options[RWRF]]),
+    Message[ReggeWheelerRadial::optx, Method -> OptionValue[Method]];
+  ];
 
-  <|"In" -> ReggeWheelerRadialFunction[s, l, \[Omega], assocIn],
-    "Up" -> ReggeWheelerRadialFunction[s, l, \[Omega], assocUp]|>
+  (* Call the chosen implementation *)
+  RWRF[s, l, \[Omega], Sequence@@subopts]
 ];
 
 

--- a/Tests/Correctness/BoundaryConditions.nb
+++ b/Tests/Correctness/BoundaryConditions.nb
@@ -1,0 +1,335 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 12.0' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[     12805,        327]
+NotebookOptionsPosition[     11299,        301]
+NotebookOutlinePosition[     11640,        316]
+CellTagsIndexPosition[     11597,        313]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+Cell[BoxData[
+ RowBox[{"<<", "ReggeWheeler`"}]], "Input",
+ CellChangeTimes->{{3.792443142501277*^9, 3.7924431445560417`*^9}},
+ CellLabel->"In[1]:=",ExpressionUUID->"9939890b-bf24-45eb-916a-d4a175e1539a"],
+
+Cell[BoxData[
+ RowBox[{"<<", "SimulationTools`"}]], "Input",
+ CellChangeTimes->{{3.792477578354884*^9, 3.792477582044091*^9}},
+ CellLabel->"In[2]:=",ExpressionUUID->"e5f33e8f-9db9-4e42-bdf6-83e9625dc744"],
+
+Cell[BoxData[{
+ RowBox[{
+  RowBox[{"M", "=", "1"}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"\[Omega]", "=", "0.1`32"}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"s", "=", "2"}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"l", "=", "2"}], ";"}]}], "Input",
+ CellChangeTimes->{{3.792477685694232*^9, 3.792477694120818*^9}},
+ CellLabel->"In[3]:=",ExpressionUUID->"1acc8737-2ed5-4ba0-9d66-49258b4fb169"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{
+   RowBox[{"rstar", "[", "r_", "]"}], ":=", 
+   RowBox[{"r", "+", 
+    RowBox[{"2", "M", " ", 
+     RowBox[{"Log", "[", 
+      RowBox[{
+       FractionBox["r", 
+        RowBox[{"2", "M"}]], "-", "1"}], "]"}]}]}]}], ";"}]], "Input",
+ CellChangeTimes->{{3.792477669686057*^9, 3.792477684524418*^9}},
+ CellLabel->"In[7]:=",ExpressionUUID->"39313483-1636-4449-87b1-e52c026a651a"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"rm2M", "[", "rstar_", "]"}], ":=", 
+  RowBox[{"2", " ", "M", " ", 
+   RowBox[{"ProductLog", "[", 
+    SuperscriptBox["\[ExponentialE]", 
+     RowBox[{
+      FractionBox["rstar", 
+       RowBox[{"2", " ", "M"}]], "-", "1"}]], "]"}]}]}]], "Input",
+ CellChangeTimes->{{3.7924779686193666`*^9, 3.7924779856955357`*^9}, {
+  3.792478045504838*^9, 3.792478051478273*^9}},
+ CellLabel->"In[8]:=",ExpressionUUID->"9c99aa5e-3ec6-47b0-9d1a-722be51fb66e"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{
+   RowBox[{"{", 
+    RowBox[{"\[Psi]In", ",", "\[Psi]Up"}], "}"}], "=", 
+   RowBox[{"Values", "[", 
+    RowBox[{"ReggeWheelerRadial", "[", 
+     RowBox[{"s", ",", "l", ",", "\[Omega]"}], "]"}], "]"}]}], ";"}]], "Input",\
+
+ CellChangeTimes->{
+  3.792443651508658*^9, {3.79244368749288*^9, 3.792443688972086*^9}, {
+   3.7924444609525642`*^9, 3.79244447878242*^9}, {3.792477436500383*^9, 
+   3.792477494742229*^9}, {3.7924777005911818`*^9, 3.792477703931548*^9}},
+ CellLabel->"In[9]:=",ExpressionUUID->"f03e2e76-ab78-44e5-9569-38a6e317b14b"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"\[Psi]Up\[ScriptCapitalI]", "=", 
+   RowBox[{"ToDataTable", "[", 
+    RowBox[{"Table", "[", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"r", ",", 
+        RowBox[{"\[Psi]Up", "[", "r", "]"}]}], "}"}], ",", 
+      RowBox[{"{", 
+       RowBox[{"r", ",", "10000", ",", "10100", ",", "5"}], "}"}]}], "]"}], 
+    "]"}]}], ";"}]], "Input",
+ CellChangeTimes->{{3.792477930159809*^9, 3.7924779456894903`*^9}, {
+  3.792478091068719*^9, 3.79247809182061*^9}},
+ CellLabel->"In[10]:=",ExpressionUUID->"9de5798a-9903-4c76-b3b6-85a7a1b91877"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"\[Psi]In\[ScriptCapitalH]", "=", 
+   RowBox[{"ToDataTable", "[", 
+    RowBox[{"Table", "[", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"rstar", ",", 
+        RowBox[{"\[Psi]In", "[", 
+         RowBox[{
+          RowBox[{"2", "M"}], "+", 
+          RowBox[{"rm2M", "[", "rstar", "]"}]}], "]"}]}], "}"}], ",", 
+      RowBox[{"{", 
+       RowBox[{"rstar", ",", 
+        RowBox[{"-", "100"}], ",", "0", ",", "5"}], "}"}]}], "]"}], "]"}]}], 
+  ";"}]], "Input",
+ CellChangeTimes->{{3.792477949582097*^9, 3.7924779627678337`*^9}, {
+  3.792478064887089*^9, 3.792478098165701*^9}, {3.792478183544976*^9, 
+  3.792478197843112*^9}, {3.792478347699214*^9, 3.792478349464218*^9}},
+ CellLabel->"In[11]:=",ExpressionUUID->"f30a1783-2a7b-4b66-aae0-3a458c713b3d"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"\[Psi]Up\[ScriptCapitalI]N", "=", 
+   RowBox[{"ReggeWheelerRadial", "[", 
+    RowBox[{"s", ",", "l", ",", "\[Omega]", ",", 
+     RowBox[{"\"\<BoundaryConditions\>\"", "\[Rule]", "\"\<Up\>\""}], ",", 
+     RowBox[{"Method", "\[Rule]", 
+      RowBox[{"{", 
+       RowBox[{"\"\<NumericalIntegration\>\"", ",", 
+        RowBox[{"\"\<Domain\>\"", "\[Rule]", 
+         RowBox[{"{", 
+          RowBox[{"10000", ",", "10100"}], "}"}]}]}], "}"}]}]}], "]"}]}], 
+  ";"}]], "Input",
+ CellChangeTimes->{{3.792478445474494*^9, 3.792478505326852*^9}, {
+   3.792501655796549*^9, 3.79250177294464*^9}, 3.7925018077697*^9},
+ CellLabel->"In[12]:=",ExpressionUUID->"e4b226df-1933-40ce-974f-a706f7f1bf82"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"\[Psi]In\[ScriptCapitalH]N", "=", 
+   RowBox[{"ReggeWheelerRadial", "[", 
+    RowBox[{"s", ",", "l", ",", "\[Omega]", ",", 
+     RowBox[{"\"\<BoundaryConditions\>\"", "\[Rule]", "\"\<In\>\""}], ",", 
+     RowBox[{"Method", "\[Rule]", 
+      RowBox[{"{", 
+       RowBox[{"\"\<NumericalIntegration\>\"", ",", 
+        RowBox[{"\"\<Domain\>\"", "\[Rule]", 
+         RowBox[{"{", 
+          RowBox[{
+           RowBox[{
+            RowBox[{"rm2M", "[", 
+             RowBox[{"-", "50"}], "]"}], "+", 
+            RowBox[{"2", "M"}]}], ",", 
+           RowBox[{
+            RowBox[{"rm2M", "[", "0", "]"}], "+", 
+            RowBox[{"2", "M"}]}]}], "}"}]}]}], "}"}]}]}], "]"}]}], 
+  ";"}]], "Input",
+ CellChangeTimes->{{3.792478445474494*^9, 3.792478537806859*^9}, {
+   3.79247857444816*^9, 3.7924785754052467`*^9}, {3.7924829776599417`*^9, 
+   3.792482990880781*^9}, {3.792501779505043*^9, 3.792501792891821*^9}, 
+   3.79250268197388*^9},
+ CellLabel->"In[20]:=",ExpressionUUID->"6c27741c-f0ce-4175-898c-f65c978b2568"],
+
+Cell[TextData[{
+ "Near \[ScriptCapitalI] the behaviour should be ",
+ Cell[BoxData[
+  FormBox[
+   RowBox[{
+    SubscriptBox["\[Psi]", "up"], "\[TildeEqual]", 
+    SuperscriptBox["\[ExponentialE]", 
+     RowBox[{"\[ImaginaryI]", " ", "\[Omega]", " ", 
+      SubscriptBox["r", "*"]}]]}], TraditionalForm]],
+  FormatType->"TraditionalForm",ExpressionUUID->
+  "aa6faa8c-7573-4449-a657-d28c2308ce22"],
+ ". This is satisfied by both MST evaluation and numerical integration."
+}], "Text",
+ CellChangeTimes->{{3.7925027507901382`*^9, 3.7925028067378187`*^9}, {
+  3.792502846260721*^9, 
+  3.792502854012632*^9}},ExpressionUUID->"6e11058f-3956-42f5-a34a-\
+a86ea7168390"],
+
+Cell[BoxData[
+ RowBox[{"Show", "[", 
+  RowBox[{
+   RowBox[{"ListPlot", "[", 
+    RowBox[{
+     RowBox[{"ReIm", "[", "\[Psi]Up\[ScriptCapitalI]", "]"}], ",", 
+     RowBox[{"PlotTheme", "\[Rule]", "\"\<Detailed\>\""}]}], "]"}], ",", 
+   RowBox[{"Plot", "[", 
+    RowBox[{
+     RowBox[{"Evaluate", "[", 
+      RowBox[{"ReIm", "[", 
+       RowBox[{"\[Psi]Up\[ScriptCapitalI]N", "[", "r", "]"}], "]"}], "]"}], 
+     ",", 
+     RowBox[{"{", 
+      RowBox[{"r", ",", "10000", ",", "10100"}], "}"}]}], "]"}], ",", 
+   RowBox[{"Plot", "[", 
+    RowBox[{
+     RowBox[{"Evaluate", "[", 
+      RowBox[{"ReIm", "[", 
+       RowBox[{"Exp", "[", 
+        RowBox[{"\[ImaginaryI]", " ", "\[Omega]", " ", 
+         RowBox[{"rstar", "[", "r", "]"}]}], "]"}], "]"}], "]"}], ",", 
+     RowBox[{"{", 
+      RowBox[{"r", ",", "10000", ",", "10100"}], "}"}], ",", 
+     RowBox[{"PlotStyle", "\[Rule]", 
+      RowBox[{"{", 
+       RowBox[{
+        RowBox[{"Directive", "[", 
+         RowBox[{
+          RowBox[{"Darker", "[", 
+           RowBox[{"ColorData", "[", 
+            RowBox[{"97", ",", "1"}], "]"}], "]"}], ",", "Dotted"}], "]"}], 
+        ",", 
+        RowBox[{"Directive", "[", 
+         RowBox[{
+          RowBox[{"Darker", "[", 
+           RowBox[{"ColorData", "[", 
+            RowBox[{"97", ",", "2"}], "]"}], "]"}], ",", "Dotted"}], "]"}]}], 
+       "}"}]}]}], "]"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.792477427923574*^9, 3.792477431222953*^9}, {
+   3.792477500243166*^9, 3.7924775996287327`*^9}, {3.792477637184228*^9, 
+   3.792477666692972*^9}, {3.7924777074835787`*^9, 3.792477740191854*^9}, 
+   3.7924779259468317`*^9, {3.792478110203144*^9, 3.792478113285878*^9}, {
+   3.792478640342547*^9, 3.792478767314073*^9}, {3.792478847160899*^9, 
+   3.792478850002668*^9}},
+ CellLabel->"In[14]:=",ExpressionUUID->"c8894332-d18a-4482-8597-994763a94a43"],
+
+Cell[TextData[{
+ "Near \[ScriptCapitalH] the behaviour should be ",
+ Cell[BoxData[
+  FormBox[
+   RowBox[{
+    SubscriptBox["\[Psi]", "in"], "\[TildeEqual]", 
+    SuperscriptBox["\[ExponentialE]", 
+     RowBox[{
+      RowBox[{"-", "\[ImaginaryI]"}], " ", "\[Omega]", " ", 
+      SubscriptBox["r", "*"]}]]}], TraditionalForm]],
+  FormatType->"TraditionalForm",ExpressionUUID->
+  "31f89029-93c1-4eca-a934-2accf7f5122d"],
+ ". This is satisfied by the MST evaluation, but not currently by numerical \
+integration."
+}], "Text",
+ CellChangeTimes->{{3.7925027507901382`*^9, 
+  3.792502841310925*^9}},ExpressionUUID->"31da910e-08dd-4972-96b7-\
+8e6921448679"],
+
+Cell[BoxData[
+ RowBox[{"Show", "[", 
+  RowBox[{
+   RowBox[{"ListPlot", "[", 
+    RowBox[{
+     RowBox[{"ReIm", "[", "\[Psi]In\[ScriptCapitalH]", "]"}], ",", 
+     RowBox[{"PlotTheme", "\[Rule]", "\"\<Detailed\>\""}]}], "]"}], ",", 
+   RowBox[{"Plot", "[", 
+    RowBox[{
+     RowBox[{"Evaluate", "[", 
+      RowBox[{"ReIm", "[", 
+       RowBox[{"\[Psi]In\[ScriptCapitalH]N", "[", 
+        RowBox[{
+         RowBox[{"rm2M", "[", "rstar", "]"}], "+", 
+         RowBox[{"2", "M"}]}], "]"}], "]"}], "]"}], ",", 
+     RowBox[{"{", 
+      RowBox[{"rstar", ",", 
+       RowBox[{"-", "50"}], ",", "0"}], "}"}]}], "]"}], ",", 
+   RowBox[{"Plot", "[", 
+    RowBox[{
+     RowBox[{"Evaluate", "[", 
+      RowBox[{"ReIm", "[", 
+       RowBox[{"Exp", "[", 
+        RowBox[{
+         RowBox[{"-", "\[ImaginaryI]"}], " ", "\[Omega]", " ", "rstar"}], 
+        "]"}], "]"}], "]"}], ",", 
+     RowBox[{"{", 
+      RowBox[{"rstar", ",", 
+       RowBox[{"-", "100"}], ",", "0"}], "}"}], ",", 
+     RowBox[{"PlotStyle", "\[Rule]", 
+      RowBox[{"{", 
+       RowBox[{
+        RowBox[{"Directive", "[", 
+         RowBox[{
+          RowBox[{"Darker", "[", 
+           RowBox[{"ColorData", "[", 
+            RowBox[{"97", ",", "1"}], "]"}], "]"}], ",", "Dotted"}], "]"}], 
+        ",", 
+        RowBox[{"Directive", "[", 
+         RowBox[{
+          RowBox[{"Darker", "[", 
+           RowBox[{"ColorData", "[", 
+            RowBox[{"97", ",", "2"}], "]"}], "]"}], ",", "Dotted"}], "]"}]}], 
+       "}"}]}]}], "]"}], ",", 
+   RowBox[{"PlotRange", "\[Rule]", "All"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.792477427923574*^9, 3.792477431222953*^9}, {
+   3.792477500243166*^9, 3.7924775996287327`*^9}, {3.792477637184228*^9, 
+   3.792477666692972*^9}, {3.7924777074835787`*^9, 3.792477740191854*^9}, 
+   3.7924779259468317`*^9, {3.792478110203144*^9, 3.792478113285878*^9}, {
+   3.792478640342547*^9, 3.792478767314073*^9}, {3.792478847160899*^9, 
+   3.7924789403435*^9}, {3.7924793433657293`*^9, 3.792479354320876*^9}, {
+   3.792502711855098*^9, 3.792502721900585*^9}},
+ CellLabel->"In[26]:=",ExpressionUUID->"eb44d9c6-af18-44d6-9c29-271638473ff8"]
+},
+WindowSize->{808, 709},
+WindowMargins->{{Automatic, -1482}, {Automatic, -96}},
+FrontEndVersion->"12.0 for Mac OS X x86 (64-bit) (April 8, 2019)",
+StyleDefinitions->"Default.nb"
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{}
+*)
+(*CellTagsIndex
+CellTagsIndex->{}
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[558, 20, 203, 3, 30, "Input",ExpressionUUID->"9939890b-bf24-45eb-916a-d4a175e1539a"],
+Cell[764, 25, 204, 3, 30, "Input",ExpressionUUID->"e5f33e8f-9db9-4e42-bdf6-83e9625dc744"],
+Cell[971, 30, 429, 10, 94, "Input",ExpressionUUID->"1acc8737-2ed5-4ba0-9d66-49258b4fb169"],
+Cell[1403, 42, 410, 11, 45, "Input",ExpressionUUID->"39313483-1636-4449-87b1-e52c026a651a"],
+Cell[1816, 55, 477, 11, 43, "Input",ExpressionUUID->"9c99aa5e-3ec6-47b0-9d1a-722be51fb66e"],
+Cell[2296, 68, 573, 13, 30, "Input",ExpressionUUID->"f03e2e76-ab78-44e5-9569-38a6e317b14b"],
+Cell[2872, 83, 569, 14, 30, "Input",ExpressionUUID->"9de5798a-9903-4c76-b3b6-85a7a1b91877"],
+Cell[3444, 99, 788, 19, 30, "Input",ExpressionUUID->"f30a1783-2a7b-4b66-aae0-3a458c713b3d"],
+Cell[4235, 120, 719, 15, 52, "Input",ExpressionUUID->"e4b226df-1933-40ce-974f-a706f7f1bf82"],
+Cell[4957, 137, 1048, 24, 52, "Input",ExpressionUUID->"6c27741c-f0ce-4175-898c-f65c978b2568"],
+Cell[6008, 163, 659, 16, 38, "Text",ExpressionUUID->"6e11058f-3956-42f5-a34a-a86ea7168390"],
+Cell[6670, 181, 1847, 45, 115, "Input",ExpressionUUID->"c8894332-d18a-4482-8597-994763a94a43"],
+Cell[8520, 228, 649, 17, 58, "Text",ExpressionUUID->"31da910e-08dd-4972-96b7-8e6921448679"],
+Cell[9172, 247, 2123, 52, 115, "Input",ExpressionUUID->"eb44d9c6-af18-44d6-9c29-271638473ff8"]
+}
+]
+*)
+

--- a/Tests/Correctness/FieldEquation.nb
+++ b/Tests/Correctness/FieldEquation.nb
@@ -1,0 +1,451 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 12.0' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[     17724,        441]
+NotebookOptionsPosition[     15274,        405]
+NotebookOutlinePosition[     15616,        420]
+CellTagsIndexPosition[     15573,        417]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+Cell[BoxData[
+ RowBox[{"<<", "ReggeWheeler`"}]], "Input",
+ CellChangeTimes->{{3.792443142501277*^9, 3.7924431445560417`*^9}},
+ CellLabel->"In[1]:=",ExpressionUUID->"9939890b-bf24-45eb-916a-d4a175e1539a"],
+
+Cell[BoxData[
+ RowBox[{"<<", "SimulationTools`"}]], "Input",
+ CellChangeTimes->{{3.792477578354884*^9, 3.792477582044091*^9}},
+ CellLabel->"In[2]:=",ExpressionUUID->"e5f33e8f-9db9-4e42-bdf6-83e9625dc744"],
+
+Cell[BoxData[{
+ RowBox[{
+  RowBox[{"M", "=", "1"}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"\[Omega]", "=", "0.1`32"}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"s", "=", "2"}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"l", "=", "2"}], ";"}]}], "Input",
+ CellChangeTimes->{{3.792477685694232*^9, 3.792477694120818*^9}},
+ CellLabel->"In[3]:=",ExpressionUUID->"1acc8737-2ed5-4ba0-9d66-49258b4fb169"],
+
+Cell["Regge-Wheeler equation", "Text",
+ CellChangeTimes->{{3.791714655619808*^9, 
+  3.7917146591412497`*^9}},ExpressionUUID->"10112520-c45c-4c35-b310-\
+fc976a67f006"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{
+   RowBox[{"RW", "[", 
+    RowBox[{"\[Psi]_", ",", "s_", ",", "\[ScriptL]_", ",", "r_"}], "]"}], ":=", 
+   RowBox[{
+    RowBox[{
+     RowBox[{"(", 
+      RowBox[{"1", "-", 
+       RowBox[{"2", 
+        RowBox[{"M", "/", "r"}]}]}], ")"}], 
+     RowBox[{
+      RowBox[{"\[Psi]", "''"}], "[", "r", "]"}]}], "+", 
+    RowBox[{
+     FractionBox[
+      RowBox[{"2", "M"}], 
+      SuperscriptBox["r", "2"]], 
+     RowBox[{
+      RowBox[{"\[Psi]", "'"}], "[", "r", "]"}]}], "+", 
+    RowBox[{
+     RowBox[{"(", 
+      RowBox[{
+       RowBox[{
+        SuperscriptBox[
+         RowBox[{"(", 
+          RowBox[{"1", "-", 
+           RowBox[{"2", 
+            RowBox[{"M", "/", "r"}]}]}], ")"}], 
+         RowBox[{"-", "1"}]], 
+        SuperscriptBox["\[Omega]", "2"]}], "-", 
+       RowBox[{"(", 
+        RowBox[{
+         FractionBox[
+          RowBox[{
+           RowBox[{"(*", 
+            RowBox[{"2", 
+             RowBox[{"(", 
+              RowBox[{"\[Lambda]", "+", "1"}], ")"}]}], "*)"}], 
+           RowBox[{"\[ScriptL]", 
+            RowBox[{"(", 
+             RowBox[{"\[ScriptL]", "+", "1"}], ")"}]}]}], 
+          SuperscriptBox["r", "2"]], "+", 
+         FractionBox[
+          RowBox[{"2", "M", 
+           RowBox[{"(", 
+            RowBox[{"1", "-", 
+             SuperscriptBox["s", "2"]}], ")"}]}], 
+          SuperscriptBox["r", "3"]]}], ")"}]}], ")"}], 
+     RowBox[{"\[Psi]", "[", "r", "]"}]}]}]}], ";"}]], "Input",
+ CellChangeTimes->{{3.792504224831987*^9, 3.792504256471884*^9}, {
+  3.792504480046554*^9, 3.7925045058775043`*^9}},
+ CellLabel->"In[7]:=",ExpressionUUID->"bd074f88-17da-49a2-b677-aa898d720578"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{
+   RowBox[{"rstar", "[", "r_", "]"}], ":=", 
+   RowBox[{"r", "+", 
+    RowBox[{"2", "M", " ", 
+     RowBox[{"Log", "[", 
+      RowBox[{
+       FractionBox["r", 
+        RowBox[{"2", "M"}]], "-", "1"}], "]"}]}]}]}], ";"}]], "Input",
+ CellChangeTimes->{{3.792477669686057*^9, 3.792477684524418*^9}},
+ CellLabel->"In[8]:=",ExpressionUUID->"39313483-1636-4449-87b1-e52c026a651a"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"rm2M", "[", "rstar_", "]"}], ":=", 
+  RowBox[{"2", " ", "M", " ", 
+   RowBox[{"ProductLog", "[", 
+    SuperscriptBox["\[ExponentialE]", 
+     RowBox[{
+      FractionBox["rstar", 
+       RowBox[{"2", " ", "M"}]], "-", "1"}]], "]"}]}]}]], "Input",
+ CellChangeTimes->{{3.7924779686193666`*^9, 3.7924779856955357`*^9}, {
+  3.792478045504838*^9, 3.792478051478273*^9}},
+ CellLabel->"In[9]:=",ExpressionUUID->"9c99aa5e-3ec6-47b0-9d1a-722be51fb66e"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{
+   RowBox[{"{", 
+    RowBox[{"\[Psi]InMST", ",", "\[Psi]UpMST"}], "}"}], "=", 
+   RowBox[{"Values", "[", 
+    RowBox[{"ReggeWheelerRadial", "[", 
+     RowBox[{"s", ",", "l", ",", "\[Omega]"}], "]"}], "]"}]}], ";"}]], "Input",\
+
+ CellChangeTimes->{
+  3.792443651508658*^9, {3.79244368749288*^9, 3.792443688972086*^9}, {
+   3.7924444609525642`*^9, 3.79244447878242*^9}, {3.792477436500383*^9, 
+   3.792477494742229*^9}, {3.7924777005911818`*^9, 3.792477703931548*^9}, {
+   3.7925045858897667`*^9, 3.792504589073003*^9}},
+ CellLabel->"In[10]:=",ExpressionUUID->"f03e2e76-ab78-44e5-9569-38a6e317b14b"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"\[Psi]UpMSTi", "=", 
+   RowBox[{"Interpolation", "[", 
+    RowBox[{
+     RowBox[{"ToDataTable", "[", 
+      RowBox[{"Table", "[", 
+       RowBox[{
+        RowBox[{"{", 
+         RowBox[{"r", ",", 
+          RowBox[{"\[Psi]UpMST", "[", "r", "]"}]}], "}"}], ",", 
+        RowBox[{"{", 
+         RowBox[{"r", ",", "8", ",", "22", ",", "0.1`32"}], "}"}]}], "]"}], 
+      "]"}], ",", 
+     RowBox[{"InterpolationOrder", "\[Rule]", "8"}]}], "]"}]}], 
+  ";"}]], "Input",
+ CellChangeTimes->{{3.792477930159809*^9, 3.7924779456894903`*^9}, {
+  3.792478091068719*^9, 3.79247809182061*^9}, {3.79250399225486*^9, 
+  3.792504054907342*^9}, {3.792504571613349*^9, 3.7925045928297157`*^9}, {
+  3.7925046695816803`*^9, 3.792504680707314*^9}, {3.792504724280748*^9, 
+  3.792504767508574*^9}, {3.792505879071231*^9, 3.792505879373954*^9}},
+ CellLabel->"In[11]:=",ExpressionUUID->"9de5798a-9903-4c76-b3b6-85a7a1b91877"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"\[Psi]InMSTi", "=", 
+   RowBox[{"Interpolation", "[", 
+    RowBox[{
+     RowBox[{"ToDataTable", "[", 
+      RowBox[{"Table", "[", 
+       RowBox[{
+        RowBox[{"{", 
+         RowBox[{"r", ",", 
+          RowBox[{"\[Psi]InMST", "[", "r", "]"}]}], "}"}], ",", 
+        RowBox[{"{", 
+         RowBox[{"r", ",", "8", ",", "22", ",", "0.1`32"}], "}"}]}], "]"}], 
+      "]"}], ",", 
+     RowBox[{"InterpolationOrder", "\[Rule]", "8"}]}], "]"}]}], 
+  ";"}]], "Input",
+ CellChangeTimes->{{3.792477949582097*^9, 3.7924779627678337`*^9}, {
+  3.792478064887089*^9, 3.792478098165701*^9}, {3.792478183544976*^9, 
+  3.792478197843112*^9}, {3.792478347699214*^9, 3.792478349464218*^9}, {
+  3.792504012089172*^9, 3.7925040237247143`*^9}, {3.792504063738408*^9, 
+  3.7925040639751387`*^9}, {3.792504595373694*^9, 3.792504600063695*^9}, {
+  3.792504684926565*^9, 3.792504685466174*^9}, {3.7925047283414373`*^9, 
+  3.792504772047949*^9}, {3.792505881197299*^9, 3.792505881399126*^9}},
+ CellLabel->"In[12]:=",ExpressionUUID->"f30a1783-2a7b-4b66-aae0-3a458c713b3d"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"\[Psi]UpNI", "=", 
+   RowBox[{"ReggeWheelerRadial", "[", 
+    RowBox[{"s", ",", "l", ",", "\[Omega]", ",", 
+     RowBox[{"\"\<BoundaryConditions\>\"", "\[Rule]", "\"\<Up\>\""}], ",", 
+     RowBox[{"Method", "\[Rule]", 
+      RowBox[{"{", 
+       RowBox[{"\"\<NumericalIntegration\>\"", ",", 
+        RowBox[{"\"\<Domain\>\"", "\[Rule]", 
+         RowBox[{"{", 
+          RowBox[{"10", ",", "20"}], "}"}]}]}], "}"}]}]}], "]"}]}], 
+  ";"}]], "Input",
+ CellChangeTimes->{{3.792478445474494*^9, 3.792478505326852*^9}, {
+   3.792501655796549*^9, 3.79250177294464*^9}, 3.7925018077697*^9, {
+   3.792503976639463*^9, 3.792503978664069*^9}, {3.792504066572949*^9, 
+   3.7925040690144577`*^9}},
+ CellLabel->"In[13]:=",ExpressionUUID->"e4b226df-1933-40ce-974f-a706f7f1bf82"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"\[Psi]InNI", "=", 
+   RowBox[{"ReggeWheelerRadial", "[", 
+    RowBox[{"s", ",", "l", ",", "\[Omega]", ",", 
+     RowBox[{"\"\<BoundaryConditions\>\"", "\[Rule]", "\"\<In\>\""}], ",", 
+     RowBox[{"Method", "\[Rule]", 
+      RowBox[{"{", 
+       RowBox[{"\"\<NumericalIntegration\>\"", ",", 
+        RowBox[{"\"\<Domain\>\"", "\[Rule]", 
+         RowBox[{"{", 
+          RowBox[{"10", ",", "20"}], "}"}]}]}], "}"}]}]}], "]"}]}], 
+  ";"}]], "Input",
+ CellChangeTimes->{{3.792478445474494*^9, 3.792478537806859*^9}, {
+   3.79247857444816*^9, 3.7924785754052467`*^9}, {3.7924829776599417`*^9, 
+   3.792482990880781*^9}, {3.792501779505043*^9, 3.792501792891821*^9}, 
+   3.79250268197388*^9, {3.792503981792129*^9, 3.792503984199285*^9}, {
+   3.792504073818843*^9, 3.7925040749883423`*^9}},
+ CellLabel->"In[14]:=",ExpressionUUID->"6c27741c-f0ce-4175-898c-f65c978b2568"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"RW\[Psi]UpNI", "=", 
+   RowBox[{"ToDataTable", "[", 
+    RowBox[{"Table", "[", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"r", ",", 
+        RowBox[{"RW", "[", 
+         RowBox[{"\[Psi]UpNI", ",", "s", ",", "l", ",", "r"}], "]"}]}], "}"}],
+       ",", 
+      RowBox[{"{", 
+       RowBox[{"r", ",", "10", ",", "20", ",", "0.01"}], "}"}]}], "]"}], 
+    "]"}]}], ";"}]], "Input",
+ CellChangeTimes->{{3.792504538991647*^9, 3.7925045414831877`*^9}},
+ CellLabel->"In[15]:=",ExpressionUUID->"6578783a-c403-4af3-bc66-4700384e217b"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"RW\[Psi]InNI", "=", 
+   RowBox[{"ToDataTable", "[", 
+    RowBox[{"Table", "[", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"r", ",", 
+        RowBox[{"RW", "[", 
+         RowBox[{"\[Psi]InNI", ",", "s", ",", "l", ",", "r"}], "]"}]}], "}"}],
+       ",", 
+      RowBox[{"{", 
+       RowBox[{"r", ",", "10", ",", "20", ",", "0.01"}], "}"}]}], "]"}], 
+    "]"}]}], ";"}]], "Input",
+ CellChangeTimes->{{3.792504538991647*^9, 3.792504548369422*^9}},
+ CellLabel->"In[16]:=",ExpressionUUID->"a3697b09-c335-42d2-8381-ba694acfa659"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"RW\[Psi]UpMSTi", "=", 
+   RowBox[{"ToDataTable", "[", 
+    RowBox[{"Table", "[", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"r", ",", 
+        RowBox[{"RW", "[", 
+         RowBox[{"\[Psi]UpMSTi", ",", "s", ",", "l", ",", "r"}], "]"}]}], 
+       "}"}], ",", 
+      RowBox[{"{", 
+       RowBox[{"r", ",", "10", ",", "20", ",", "0.01"}], "}"}]}], "]"}], 
+    "]"}]}], ";"}]], "Input",
+ CellChangeTimes->{{3.792504538991647*^9, 3.7925045414831877`*^9}, {
+  3.792504613925898*^9, 3.792504618686607*^9}},
+ CellLabel->"In[17]:=",ExpressionUUID->"5b0b00b5-bf60-420f-b7c7-fe166405f5a6"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"RW\[Psi]InMSTi", "=", 
+   RowBox[{"ToDataTable", "[", 
+    RowBox[{"Table", "[", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"r", ",", 
+        RowBox[{"RW", "[", 
+         RowBox[{"\[Psi]InMSTi", ",", "s", ",", "l", ",", "r"}], "]"}]}], 
+       "}"}], ",", 
+      RowBox[{"{", 
+       RowBox[{"r", ",", "10", ",", "20", ",", "0.01"}], "}"}]}], "]"}], 
+    "]"}]}], ";"}]], "Input",
+ CellChangeTimes->{{3.792504538991647*^9, 3.792504548369422*^9}, {
+  3.792504621373519*^9, 3.7925046236813297`*^9}},
+ CellLabel->"In[18]:=",ExpressionUUID->"72a8e613-bb23-450d-b2f7-bf1990fb097f"],
+
+Cell[BoxData[
+ RowBox[{"Monitor", "[", 
+  RowBox[{
+   RowBox[{
+    RowBox[{"RW\[Psi]UpMST", "=", 
+     RowBox[{"ToDataTable", "[", 
+      RowBox[{"Table", "[", 
+       RowBox[{
+        RowBox[{"{", 
+         RowBox[{"r", ",", 
+          RowBox[{"RW", "[", 
+           RowBox[{"\[Psi]UpMST", ",", "s", ",", "l", ",", "r"}], "]"}]}], 
+         "}"}], ",", 
+        RowBox[{"{", 
+         RowBox[{"r", ",", "10", ",", "20", ",", "0.1"}], "}"}]}], "]"}], 
+      "]"}]}], ";"}], ",", "r"}], "]"}]], "Input",
+ CellChangeTimes->{{3.792504538991647*^9, 3.7925045414831877`*^9}, {
+   3.792504613925898*^9, 3.792504618686607*^9}, {3.7925048062277822`*^9, 
+   3.7925048351859093`*^9}, 3.792504874957032*^9},
+ CellLabel->"In[19]:=",ExpressionUUID->"1662d2c3-d44f-4da6-9def-99c1b52d0f30"],
+
+Cell[BoxData[
+ RowBox[{"Monitor", "[", 
+  RowBox[{
+   RowBox[{
+    RowBox[{"RW\[Psi]InMST", "=", 
+     RowBox[{"ToDataTable", "[", 
+      RowBox[{"Table", "[", 
+       RowBox[{
+        RowBox[{"{", 
+         RowBox[{"r", ",", 
+          RowBox[{"RW", "[", 
+           RowBox[{"\[Psi]InMST", ",", "s", ",", "l", ",", "r"}], "]"}]}], 
+         "}"}], ",", 
+        RowBox[{"{", 
+         RowBox[{"r", ",", "10", ",", "20", ",", "0.1"}], "}"}]}], "]"}], 
+      "]"}]}], ";"}], ",", "r"}], "]"}]], "Input",
+ CellChangeTimes->{{3.792504538991647*^9, 3.792504548369422*^9}, {
+  3.792504621373519*^9, 3.7925046236813297`*^9}, {3.792504842172673*^9, 
+  3.792504877069704*^9}},
+ CellLabel->"In[20]:=",ExpressionUUID->"01b1dd19-52dd-4567-bf78-9369acbf68ca"],
+
+Cell[BoxData[
+ RowBox[{"ListPlot", "[", 
+  RowBox[{
+   RowBox[{"ReIm", "[", "RW\[Psi]UpNI", "]"}], ",", 
+   RowBox[{"PlotRange", "\[Rule]", "All"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.7925041043256207`*^9, 3.792504122544262*^9}, {
+   3.792504268642099*^9, 3.792504393907064*^9}, 3.792504441753337*^9, {
+   3.792504511997945*^9, 3.792504553873502*^9}},
+ CellLabel->"In[21]:=",ExpressionUUID->"affee657-7e36-41ea-a9b3-cef3874648d5"],
+
+Cell[BoxData[
+ RowBox[{"ListPlot", "[", 
+  RowBox[{
+   RowBox[{"ReIm", "[", "RW\[Psi]InNI", "]"}], ",", 
+   RowBox[{"PlotRange", "\[Rule]", "All"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.7925041043256207`*^9, 3.792504122544262*^9}, {
+   3.792504268642099*^9, 3.792504393907064*^9}, 3.792504441753337*^9, {
+   3.792504511997945*^9, 3.79250455973216*^9}},
+ CellLabel->"In[22]:=",ExpressionUUID->"1d395622-6be5-4f64-a82a-cec3a0f9b328"],
+
+Cell[BoxData[
+ RowBox[{"ListPlot", "[", 
+  RowBox[{
+   RowBox[{"ReIm", "[", "RW\[Psi]UpMSTi", "]"}], ",", 
+   RowBox[{"PlotRange", "\[Rule]", "All"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.7925041043256207`*^9, 3.792504122544262*^9}, {
+   3.792504268642099*^9, 3.792504393907064*^9}, 3.792504441753337*^9, {
+   3.792504511997945*^9, 3.792504553873502*^9}, {3.792504703882752*^9, 
+   3.792504705345264*^9}},
+ CellLabel->"In[23]:=",ExpressionUUID->"3901b73a-4b16-455a-acb4-68a328cd7df2"],
+
+Cell[BoxData[
+ RowBox[{"ListPlot", "[", 
+  RowBox[{
+   RowBox[{"ReIm", "[", "RW\[Psi]InMSTi", "]"}], ",", 
+   RowBox[{"PlotRange", "\[Rule]", "All"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.7925041043256207`*^9, 3.792504122544262*^9}, {
+   3.792504268642099*^9, 3.792504393907064*^9}, 3.792504441753337*^9, {
+   3.792504511997945*^9, 3.79250455973216*^9}, {3.792504708653714*^9, 
+   3.792504713209338*^9}},
+ CellLabel->"In[24]:=",ExpressionUUID->"6fbd8ae5-5075-4982-bfe5-dead0f22e5ef"],
+
+Cell[BoxData[
+ RowBox[{"ListPlot", "[", 
+  RowBox[{
+   RowBox[{"ReIm", "[", "RW\[Psi]UpMST", "]"}], ",", 
+   RowBox[{"PlotRange", "\[Rule]", "All"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.7925041043256207`*^9, 3.792504122544262*^9}, {
+   3.792504268642099*^9, 3.792504393907064*^9}, 3.792504441753337*^9, {
+   3.792504511997945*^9, 3.792504553873502*^9}, {3.792504703882752*^9, 
+   3.792504705345264*^9}, 3.79250488721882*^9},
+ CellLabel->"In[25]:=",ExpressionUUID->"4c081aef-4aa2-4ce3-b885-f3bb1a002cfe"],
+
+Cell[BoxData[
+ RowBox[{"ListPlot", "[", 
+  RowBox[{
+   RowBox[{"ReIm", "[", "RW\[Psi]InMST", "]"}], ",", 
+   RowBox[{"PlotRange", "\[Rule]", "All"}]}], "]"}]], "Input",
+ CellChangeTimes->{{3.7925041043256207`*^9, 3.792504122544262*^9}, {
+   3.792504268642099*^9, 3.792504393907064*^9}, 3.792504441753337*^9, {
+   3.792504511997945*^9, 3.79250455973216*^9}, {3.792504708653714*^9, 
+   3.792504713209338*^9}, 3.79250488950266*^9},
+ CellLabel->"In[26]:=",ExpressionUUID->"54edadae-15dd-42a4-a371-03ad6d7cab17"]
+},
+WindowSize->{808, 709},
+WindowMargins->{{Automatic, -1317}, {Automatic, -102}},
+FrontEndVersion->"12.0 for Mac OS X x86 (64-bit) (April 8, 2019)",
+StyleDefinitions->"Default.nb"
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{}
+*)
+(*CellTagsIndex
+CellTagsIndex->{}
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[558, 20, 203, 3, 30, "Input",ExpressionUUID->"9939890b-bf24-45eb-916a-d4a175e1539a"],
+Cell[764, 25, 204, 3, 30, "Input",ExpressionUUID->"e5f33e8f-9db9-4e42-bdf6-83e9625dc744"],
+Cell[971, 30, 429, 10, 94, "Input",ExpressionUUID->"1acc8737-2ed5-4ba0-9d66-49258b4fb169"],
+Cell[1403, 42, 166, 3, 35, "Text",ExpressionUUID->"10112520-c45c-4c35-b310-fc976a67f006"],
+Cell[1572, 47, 1656, 51, 98, "Input",ExpressionUUID->"bd074f88-17da-49a2-b677-aa898d720578"],
+Cell[3231, 100, 410, 11, 45, "Input",ExpressionUUID->"39313483-1636-4449-87b1-e52c026a651a"],
+Cell[3644, 113, 477, 11, 43, "Input",ExpressionUUID->"9c99aa5e-3ec6-47b0-9d1a-722be51fb66e"],
+Cell[4124, 126, 632, 14, 30, "Input",ExpressionUUID->"f03e2e76-ab78-44e5-9569-38a6e317b14b"],
+Cell[4759, 142, 935, 21, 52, "Input",ExpressionUUID->"9de5798a-9903-4c76-b3b6-85a7a1b91877"],
+Cell[5697, 165, 1083, 23, 52, "Input",ExpressionUUID->"f30a1783-2a7b-4b66-aae0-3a458c713b3d"],
+Cell[6783, 190, 799, 17, 52, "Input",ExpressionUUID->"e4b226df-1933-40ce-974f-a706f7f1bf82"],
+Cell[7585, 209, 900, 18, 52, "Input",ExpressionUUID->"6c27741c-f0ce-4175-898c-f65c978b2568"],
+Cell[8488, 229, 565, 15, 30, "Input",ExpressionUUID->"6578783a-c403-4af3-bc66-4700384e217b"],
+Cell[9056, 246, 563, 15, 30, "Input",ExpressionUUID->"a3697b09-c335-42d2-8381-ba694acfa659"],
+Cell[9622, 263, 619, 16, 30, "Input",ExpressionUUID->"5b0b00b5-bf60-420f-b7c7-fe166405f5a6"],
+Cell[10244, 281, 619, 16, 30, "Input",ExpressionUUID->"72a8e613-bb23-450d-b2f7-bf1990fb097f"],
+Cell[10866, 299, 775, 19, 52, "Input",ExpressionUUID->"1662d2c3-d44f-4da6-9def-99c1b52d0f30"],
+Cell[11644, 320, 747, 19, 52, "Input",ExpressionUUID->"01b1dd19-52dd-4567-bf78-9369acbf68ca"],
+Cell[12394, 341, 436, 8, 30, "Input",ExpressionUUID->"affee657-7e36-41ea-a9b3-cef3874648d5"],
+Cell[12833, 351, 435, 8, 30, "Input",ExpressionUUID->"1d395622-6be5-4f64-a82a-cec3a0f9b328"],
+Cell[13271, 361, 488, 9, 30, "Input",ExpressionUUID->"3901b73a-4b16-455a-acb4-68a328cd7df2"],
+Cell[13762, 372, 487, 9, 30, "Input",ExpressionUUID->"6fbd8ae5-5075-4982-bfe5-dead0f22e5ef"],
+Cell[14252, 383, 508, 9, 30, "Input",ExpressionUUID->"4c081aef-4aa2-4ce3-b885-f3bb1a002cfe"],
+Cell[14763, 394, 507, 9, 30, "Input",ExpressionUUID->"54edadae-15dd-42a4-a371-03ad6d7cab17"]
+}
+]
+*)
+
+(* End of internal cache information *)
+


### PR DESCRIPTION
This is a rewrite of the interface part of the package, to simplify things and make the option handling more robust. It removes support for having multiple homogeneous solutions inside a single ReggeWheelerRadialFunction as it over-complicated things with little gain.