### PR TITLE
Fixing PointParticleMode

### DIFF
--- a/Kernel/ConvolveSource.m
+++ b/Kernel/ConvolveSource.m
@@ -37,33 +37,14 @@ ConvolveSource[RF_, SF_, SO_] :=Module[{s},
 
 
 ConvolvePointParticleSourceCircular[(-2|2),RF_,SO_]:=
-	Module[{l,m,r0,PsiIn,dPsiIn,PsiUp,dPsiUp,PsiOddIn,dPsiOddIndr,PsiOddUp,dPsiOddUpdr,Wronskian,deltadPsidr,deltaPsi,n,np6M,denom,conjdenom,b,c,\[Omega],rm2M,ZIn,ZUp,jump},
-		l=SO["l"];
-		m=SO["m"];
+	Module[{r0,PsiIn,dPsiIn,PsiUp,dPsiUp,Wronskian,deltadPsidr,deltaPsi,ZIn,ZUp},
+
 		r0=SO["r0"];
-		\[Omega]=m*Sqrt[1/r0^3];
-		rm2M=r0-2;
-		If[EvenQ[l+m],
-			PsiOddIn=RF["In"][r0];
-			dPsiOddIndr=RF["In"]'[r0];
-			PsiOddUp=RF["Up"][r0];
-			dPsiOddUpdr=RF["Up"]'[r0];
-			n=(l-1)*(l+2);
-			np6M=n*r0+6;
-			denom=n*(n+2)+12*I*\[Omega];
-			conjdenom=n*(n+2)-12*I*\[Omega];
-			b=((r0*n)^2*(np6M+2*r0)+12*r0^2*n+72*rm2M)/(r0^2*np6M);
-			c=((r0*n)^2*(np6M+2*r0)+12*r0^2*n+36*rm2M)*12/r0/(r0*np6M)^2;
-			PsiIn=(12*(1-2/r0)*dPsiOddIndr+b*PsiOddIn)/conjdenom;
-			PsiUp=(12*(1-2/r0)*dPsiOddUpdr+b*PsiOddUp)/denom;
-			dPsiIn=(-12*\[Omega]^2/(1-2/r0)*PsiOddIn+c*PsiOddIn+b*dPsiOddIndr)/conjdenom;
-			dPsiUp=(-12*\[Omega]^2/(1-2/r0)*PsiOddUp+c*PsiOddUp+b*dPsiOddUpdr)/denom;
-		,
-			PsiIn=RF["In"][r0];
-			dPsiIn=RF["In"]'[r0];
-			PsiUp=RF["Up"][r0];
-			dPsiUp=RF["Up"]'[r0];
-		];
+
+		PsiIn=RF["In"][r0];
+		dPsiIn=RF["In"]'[r0];
+		PsiUp=RF["Up"][r0];
+		dPsiUp=RF["Up"]'[r0];
 		
 		Wronskian = PsiIn*dPsiUp - PsiUp*dPsiIn;
 		deltaPsi=SO["deltaPsi"];
@@ -71,7 +52,7 @@ ConvolvePointParticleSourceCircular[(-2|2),RF_,SO_]:=
 		ZIn = (PsiUp*deltadPsidr - deltaPsi*dPsiUp)/Wronskian;
 		ZUp = (PsiIn*deltadPsidr - deltaPsi*dPsiIn)/Wronskian;
 		<|"\[ScriptCapitalI]" -> ZUp, "\[ScriptCapitalH]" -> ZIn|>
-	];
+];
 
 
 (* ::Section::Closed:: *)

--- a/Kernel/ReggeWheelerMode.m
+++ b/Kernel/ReggeWheelerMode.m
@@ -64,7 +64,7 @@ Options[ReggeWheelerPointParticleMode] = {};
 
 
 ReggeWheelerPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, orbit_KerrGeoOrbitFunction, opts:OptionsPattern[]] /; AllTrue[orbit["Frequencies"], InexactNumberQ] :=
- Module[{source, assoc, R, S, \[Omega], \[CapitalOmega]r, \[CapitalOmega]\[Phi], \[CapitalOmega]\[Theta], Z},
+ Module[{source, assoc, radialopts, R, S, \[Omega], \[CapitalOmega]r, \[CapitalOmega]\[Phi], \[CapitalOmega]\[Theta], Z},
   If[orbit["a"] != 0,
     Message[ReggeWheelerPointParticleMode::nospin, orbit["a"]];
     Return[$Failed];
@@ -76,7 +76,12 @@ ReggeWheelerPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, orbit_
 
   source = ReggeWheeler`ReggeWheelerSource`Private`ReggeWheelerPointParticleSource[s, l, m, orbit];
 
-  R = ReggeWheelerRadial[s, l, \[Omega]];
+  radialopts = Sequence@@FilterRules[{opts}, Options[ReggeWheelerRadial]]; (*May need to remove the "Potential" option if it's in this list!*)
+  If[EvenQ[l+m], (*Switch for parity of the homogeneous solution*)
+      R = ReggeWheelerRadial[s, l, \[Omega], "Potential"->"Zerilli", radialopts];
+  ,
+      R = ReggeWheelerRadial[s, l, \[Omega], "Potential"->"ReggeWheeler", radialopts];
+  ];
   S = SpinWeightedSpheroidalHarmonicS[s, l, m, 0];
   Z = ReggeWheeler`ConvolveSource`Private`ConvolveSource[R, S, source];
 


### PR DESCRIPTION
This change should allow for the even-parity modes to correctly be used when computing the circular orbit particular solutions.